### PR TITLE
feat: Update date and time formatting to align with GovUK style guide…

### DIFF
--- a/src/nunjucks-filters/local-date-time-filter.ts
+++ b/src/nunjucks-filters/local-date-time-filter.ts
@@ -11,8 +11,21 @@ export const asLocalTime = localDateFormat('h:mma'); // "3:30pm" (GDS recommende
 export const asLocalTimeWithoutAmPm = localDateFormat('h:mm'); // "3:30"
 export const asWeekday = localDateFormat('dddd'); // "Tuesday"
 
+const replacements = [
+  { pattern: /12:00am/i, replacement: 'midnight' },
+  { pattern: /12:00pm/i, replacement: 'midday' }
+];
+
 function localDateFormat(mask: string): (isoDate: string) => string {
-  return (isoDate: string): string => dayjs(isoDate).tz(config.defaultTimeZone).format(mask);
+  return (isoDate: string): string => {
+    let formattedTime = dayjs(isoDate).tz(config.defaultTimeZone).format(mask);
+
+    replacements.forEach(({ pattern, replacement }) => {
+      formattedTime = formattedTime.replace(pattern, replacement);
+    });
+
+    return formattedTime;
+  };
 }
 
 export function toISODateString(date: string): string {

--- a/tests/unit/filters.test.ts
+++ b/tests/unit/filters.test.ts
@@ -22,10 +22,13 @@ describe('Nunjucks custom date/time dateTimeFilters tests', () => {
     });
   });
 
-  describe('asFullDateTimeWithoutWeekday', () => {
-    test('returns the date in the format "10:00am, 8 November 2018" given an ISO datetime string', () => {
-      const isoDateString = '2018-11-08T10:00:56Z';
-      expect(asFullDateTimeWithoutWeekday(isoDateString)).toBe('10:00am, 8 November 2018');
+  describe.each([
+    ['2018-11-08T10:00:56Z', '10:00am, 8 November 2018'],
+    ['2018-11-08T12:00:00Z', 'midday, 8 November 2018'],
+    ['2018-11-08T00:00:00Z', 'midnight, 8 November 2018']
+  ])('asFullDateTimeWithoutWeekday', (isoDateString, expectedResult) => {
+    test(`returns the date as ${expectedResult} given an ISO datetime string: ${isoDateString}`, () => {
+      expect(asFullDateTimeWithoutWeekday(isoDateString)).toBe(expectedResult);
     });
   });
 
@@ -43,10 +46,13 @@ describe('Nunjucks custom date/time dateTimeFilters tests', () => {
     });
   });
 
-  describe('asLocalTime', () => {
-    test('returns the local time in the format "5:30pm" given an ISO datetime string', () => {
-      const isoDateString = '2018-11-08T17:30:56Z';
-      expect(asLocalTime(isoDateString)).toBe('5:30pm');
+  describe.each([
+      ['2018-11-08T17:30:56Z', '5:30pm'],
+      ['2018-11-08T12:00:00Z', 'midday'],
+      ['2018-11-08T00:00:00Z', 'midnight']
+  ])('asLocalTime', (isoDateString, expectedResult) => {
+    test(`returns the local time as ${expectedResult} given an ISO datetime string: ${isoDateString}`, () => {
+      expect(asLocalTime(isoDateString)).toBe(expectedResult);
     });
   });
 


### PR DESCRIPTION
## Description

This pull request updates date and time formatting in line with [GovUK style guidelines](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times). It introduces "midday" and "midnight" formatting for 12:00pm and 12:00am. Test cases ensure the correct formatting.

## Changes Made

- Added `localDateTimeFormat` for GovUK-compliant date and time formatting.
- Updated `asFullDateTimeWithoutWeekday` and `asLocalTime` accordingly.
- Modified test cases in `filters.test.ts` to reflect the new formatting rules.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
